### PR TITLE
Should fix error

### DIFF
--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -221,11 +221,6 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 						return;
 					}
 				}
-
-				cancel();
-				actual.onError(Exceptions.failWithOverflow(
-						"Could not emit buffer due to lack of requests"));
-				Operators.onDiscardMultiple(v, this.actual.currentContext());
 			}
 		}
 

--- a/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
+++ b/reactor-core/src/main/java/reactor/core/publisher/FluxBufferTimeout.java
@@ -198,7 +198,7 @@ final class FluxBufferTimeout<T, C extends Collection<? super T>> extends Intern
 				}
 			}
 
-			if (flush) {
+			if (flush && requested > 0) {
 				long r = requested;
 				if (r != 0L) {
 					if (r != Long.MAX_VALUE) {


### PR DESCRIPTION
reactor.core.Exceptions$OverflowException: Could not emit buffer due to lack of requests

	at reactor.core.Exceptions.failWithOverflow(Exceptions.java:234)
	at reactor.core.publisher.FluxBufferTimeout$BufferTimeoutSubscriber.flushCallback(FluxBufferTimeout.java:221)
	at reactor.core.publisher.FluxBufferTimeout$BufferTimeoutSubscriber.lambda$new$0(FluxBufferTimeout.java:150)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:84)
	at reactor.core.scheduler.WorkerTask.call(WorkerTask.java:37)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201

```java
 @Test
    public void testDelay() {

        final AtomicInteger count = new AtomicInteger(3);
        Flux.range(0, 1_000)
            .log("Range.", Level.FINE, SignalType.REQUEST, SignalType.ON_NEXT)
            .doOnRequest(req -> log.debug("On Request {}", req))
            .log("", Level.FINE, SignalType.ON_NEXT)
            .bufferTimeout(1000, Duration.ofMillis(10))
            .doOnNext(w -> log.debug("Got buffer {}", w.size()))
            .flatMapSequential(integers -> Flux.fromIterable(integers)
                                               .flatMap(i -> Mono.delay(Duration.ofSeconds((int) (Math.random() * 30) / 10 + 1))
                                                                 .doFinally(signalType -> log.debug("Batch Complete {}", i)))
                                               .subscribeOn(Schedulers.parallel()),
                               3)
            .blockLast();
    }
```